### PR TITLE
Enhance README and fix requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains code for our paper _Systematic Evaluation of LLM-as-a-J
 
 ![Evaluation Framework](./example_results/framework.jpg)
 
-In this work, we systematically evaluate LLM-as-a-Judge methodology on two LLM alignment datasets (i.e `TL;DR Summerization` and `HH-RLHF-Helpful`):
+In this work, we systematically evaluate LLM-as-a-Judge methodology on two LLM alignment datasets (i.e., `TL;DR Summarization` and `HH-RLHF-Helpful`):
 
 - we define evaluation metrics with improved theoretical interpretability.
 - we develop a framework to evaluate, compare, and visualize the reliability and alignment of LLM judges.
@@ -18,7 +18,7 @@ In this work, we systematically evaluate LLM-as-a-Judge methodology on two LLM a
 Run the following command to install the required Python packages.
 
 ```bash
-# The python environment has been tested on python=3.8, 3.8.19, 3.9.6
+# The Python environment has been tested on python=3.8, 3.8.19, 3.9.6
 pip install -r requirements.txt
 ```
 
@@ -27,7 +27,7 @@ Then set the Python path to the current directory.
 ```bash
 export PYTHONPATH=$PYTHONPATH:$(pwd)
 ```
-If you want to use use a different LLM provided exposing OpenAI compatible API, you can define the `OPENAI_API_KEY` environment variable. For example with server from LM Studio running on port 1234:
+If you want to use a different LLM provided exposing OpenAI compatible API, you can define the `OPENAI_API_KEY` environment variable. For example with server from LM Studio running on port 1234:
 
 ```bash
 export OPENAI_BASE_URL="http://localhost:1234/v1"
@@ -37,7 +37,7 @@ export OPENAI_BASE_URL="http://localhost:1234/v1"
 ### Dataset Preprocessing
 
 Use the following command to prepare a formatted dataset for the LLM judge evaluation process.
-The default dir to save the processed dataset `./datasets/formatted_datasets`.
+The default dir to save the processed dataset is `./datasets/formatted_datasets`.
 The `dataset_id` identifies the formatted dataset, which is better kept consistent in the following steps.
 For example:
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,54 @@
 ## Systematic Evaluation of LLM-as-a-Judge in LLM Alignment Tasks: Explainable Metrics and Diverse Prompt Templates
 
 ### Introduction
-This repository contains code for our paper _Systematic Evaluation of LLM-as-a-Judge in LLM Alignment Tasks: Explainable Metrics and Diverse Prompt Templates_. [[arXiv](https://arxiv.org/pdf/2408.13006)]
+
+This repository contains code for our paper _Systematic Evaluation of LLM-as-a-Judge in LLM Alignment Tasks: Explainable Metrics and Diverse Prompt Templates_. \[[arXiv](https://arxiv.org/pdf/2408.13006)\]
 
 ![Evaluation Framework](./example_results/framework.jpg)
 
+In this work, we systematically evaluate LLM-as-a-Judge methodology on two LLM alignment datasets (i.e `TL;DR Summerization` and `HH-RLHF-Helpful`):
 
-In this work, we systematically evaluate LLM-as-a-Judge methodology on two LLM alignment datasets (i.e ``TL;DR Summerization`` and ``HH-RLHF-Helpful``):
-* we define evaluation metrics with improved theoretical interpretability. 
-* we develop a framework to evaluate, compare, and visualize the reliability and alignment of LLM judges.
-* we investigate the effect of diverse prompt templates on LLM-judge reliability. 
-* our results indicate a significant impact of prompt templates on LLM judge performance, as well as a mediocre alignment level between the tested LLM judges and human evaluators.
+- we define evaluation metrics with improved theoretical interpretability.
+- we develop a framework to evaluate, compare, and visualize the reliability and alignment of LLM judges.
+- we investigate the effect of diverse prompt templates on LLM-judge reliability.
+- our results indicate a significant impact of prompt templates on LLM judge performance, as well as a mediocre alignment level between the tested LLM judges and human evaluators.
 
 ### Package installation
+
 Run the following command to install the required Python packages.
+
 ```bash
 # The python environment has been tested on python=3.8, 3.8.19, 3.9.6
 pip install -r requirements.txt
 ```
 
-### Dataset Preprocessing
-Use the following command to prepare a formatted dataset for the LLM judge evaluation process. 
-The default dir to save the processed dataset ``./datasets/formatted_datasets``. 
-The ``dataset_id`` identifies the formatted dataset, which is better kept consistent in the following steps.
+Then set the Python path to the current directory.
 
 ```bash
-python datasets/data_preprocessing.py \      
+export PYTHONPATH=$PYTHONPATH:$(pwd)
+```
+
+### Dataset Preprocessing
+
+Use the following command to prepare a formatted dataset for the LLM judge evaluation process.
+The default dir to save the processed dataset `./datasets/formatted_datasets`.
+The `dataset_id` identifies the formatted dataset, which is better kept consistent in the following steps.
+
+```bash
+python datasets/data_preprocessing.py \
 --data-path datasets/raw_datasets/ \         # directory to save downloaded dataset from the original data source
 --output-dir datasets/formatted_datasets/ \  # directory to save the processed datasets
 --dataset-id summarize                       # summarize, hhrlhf_helpful
 ```
 
 ### Add OpenAI Key
-Add your own OpenAI key to ``configs/openai_api_key.py`` in order to evaluate LLM judges.
+
+Add your own OpenAI key to `configs/openai_api_key.py` in order to evaluate LLM judges.
 
 ### Evaluate a Set of LLM Judges by Metric Computation and Visualization
-Use the example below to evaluate a set of LLM judges using the example dataset ``dataset_id=summarize``.
-The templates are specified in ``templates/dataset_id`` folders.
+
+Use the example below to evaluate a set of LLM judges using the example dataset `dataset_id=summarize`.
+The templates are specified in `templates/dataset_id` folders.
 
 ```bash
 python eval/eval_llm_judges.py \
@@ -45,7 +57,7 @@ python eval/eval_llm_judges.py \
 --split_size 200 \        # number of samples in each split
 --num_splits 5 \          # number of splits
 --self_consist_id 0 \     # index of split used to compute self-consistency results
---num_runs 5 \            # number of repetition to run the split to compute the self-consistency results                                                                     
+--num_runs 5 \            # number of repetition to run the split to compute the self-consistency results
 --num_eval -1 \           # number of evaluated samples in each split (-1 means all samples in the split)
 --models "['gpt-4o-mini']" \  # list of LLM names
 --templates "['chen-2023_summarize', 'guo-2024_summarize']" \  # list of templates
@@ -58,8 +70,11 @@ python eval/eval_llm_judges.py \
 ```
 
 ### Example Evaluation Results
+
 #### Metric Report Tables
-Metric report tables related to evaluating LLM judges (``model:GPT-4o`` with different templates) on the ``TL;DR Summarization`` dataset.
+
+Metric report tables related to evaluating LLM judges (`model:GPT-4o` with different templates) on the `TL;DR Summarization` dataset.
+
 <div style="display: grid; grid-template-columns: repeat(1, 1fr); gap: 2px; text-align: center;" >
   <div>
     <img src="./example_results/metrics_table.jpg" alt="Accuracy (Both)" style="width:70%;">
@@ -67,12 +82,13 @@ Metric report tables related to evaluating LLM judges (``model:GPT-4o`` with dif
 </div>
 
 #### Visualization Results
-Visualization results related to evaluating LLM judges (models + different templates) on the ``TL;DR Summarization`` dataset.\
+
+Visualization results related to evaluating LLM judges (models + different templates) on the `TL;DR Summarization` dataset.\
 <img src="./example_results/accuracy_both_summary.png" width="300"/>   <img src="./example_results/position_bias_summary.png" width="300"/>
 <img src="./example_results/length_bias_summary.png" width="300"/>   <img src="./example_results/position_bias_accuracy_summary.png" width="300"/>
 
-
 ### References
+
 ```
 @article{wei2024systematic,
   title={Systematic Evaluation of LLM-as-a-Judge in LLM Alignment Tasks: Explainable Metrics and Diverse Prompt Templates},

--- a/README.md
+++ b/README.md
@@ -27,19 +27,28 @@ Then set the Python path to the current directory.
 ```bash
 export PYTHONPATH=$PYTHONPATH:$(pwd)
 ```
+If you want to use use a different LLM provided exposing OpenAI compatible API, you can define the `OPENAI_API_KEY` environment variable. For example with server from LM Studio running on port 1234:
+
+```bash
+export OPENAI_BASE_URL="http://localhost:1234/v1"
+```
+
 
 ### Dataset Preprocessing
 
 Use the following command to prepare a formatted dataset for the LLM judge evaluation process.
 The default dir to save the processed dataset `./datasets/formatted_datasets`.
 The `dataset_id` identifies the formatted dataset, which is better kept consistent in the following steps.
+For example:
 
 ```bash
 python datasets/data_preprocessing.py \
---data-path datasets/raw_datasets/ \         # directory to save downloaded dataset from the original data source
---output-dir datasets/formatted_datasets/ \  # directory to save the processed datasets
---dataset-id summarize                       # summarize, hhrlhf_helpful
+--data-path datasets/raw_datasets/ \
+--output-dir datasets/formatted_datasets/ \
+--dataset-id summarize
 ```
+
+For more options, run `python datasets/data_preprocessing.py -h`.
 
 ### Add OpenAI Key
 
@@ -48,26 +57,28 @@ Add your own OpenAI key to `configs/openai_api_key.py` in order to evaluate LLM 
 ### Evaluate a Set of LLM Judges by Metric Computation and Visualization
 
 Use the example below to evaluate a set of LLM judges using the example dataset `dataset_id=summarize`.
-The templates are specified in `templates/dataset_id` folders.
+The templates are specified in `templates/dataset_id` folders. For example:
 
 ```bash
 python eval/eval_llm_judges.py \
---processed_data_path ./datasets/formatted_datasets/summarize/data.summarize.xxxx-xx-xx.jsonl \  # data path to the preprocessed dataset
---dataset_id summarize \  # dataset task (summarize or hhrlhf-helpful)
---split_size 200 \        # number of samples in each split
---num_splits 5 \          # number of splits
---self_consist_id 0 \     # index of split used to compute self-consistency results
---num_runs 5 \            # number of repetition to run the split to compute the self-consistency results
---num_eval -1 \           # number of evaluated samples in each split (-1 means all samples in the split)
---models "['gpt-4o-mini']" \  # list of LLM names
---templates "['chen-2023_summarize', 'guo-2024_summarize']" \  # list of templates
---extract_rule combine \  # rule to make binary output from the judging results ("combine", "chosen_reject" or "reject_chosen")
---temperature 0.1 \       # temperature parameter used for LLM inference
---num_workers 8 \         # number of processes to run judging results in parallel
---use_cache_samples \     # if use cached sampling results
---use_cache_results \     # if use cached computation and visualization results
---cache_dir ./outputs/    # directory to store the output results
+  --processed_data_path ./datasets/formatted_datasets/summarize/data.summarize.xxxx_xx_xx.jsonl \
+  --dataset_id summarize \
+  --split_size 200 \
+  --num_splits 5 \
+  --self_consist_id 0 \
+  --num_runs 5 \
+  --num_eval -1 \
+  --models "['gpt-4o-mini']" \
+  --templates "['chen-2023_summarize', 'guo-2024_summarize']" \
+  --extract_rule combine \
+  --temperature 0.1 \
+  --num_workers 8 \
+  --use_cache_samples \
+  --use_cache_results \
+  --cache_dir ./outputs/
 ```
+
+Run `python eval/eval_llm_judges.py -h` to see all the available options.
 
 ### Example Evaluation Results
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ matplotlib==3.7.5
 numpy==1.21.0
 pandas==2.0.3
 scipy==1.10.1
-tqdm==4.66.1
-typing-extensions==4.9.0
+tqdm>=4.66.1
+typing-extensions>=4.9.0
 regex==2024.7.24
 openai==1.51.2
+datasets==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ typing-extensions>=4.9.0
 regex==2024.7.24
 openai==1.51.2
 datasets==3.1.0
+scikit-learn==1.5.1


### PR DESCRIPTION
## README
- Export `PYTHONPATH`. This is required if the code base is not a Python package. Probably VSCode (and other IDEs) do this automatically.
- Experiment with local models. Assuming that you have a server running an OpenAI-compatible API (LM Studio, Ollama, vllm, ...), you can experiment with other models by simply exporting the environment variable `OPENAI_BASE_URL`.
- Remove comments from bash code blocks so that the commands can be copied and run directly in the terminal. The full parameter descriptions can be accessed with the `-h/--help` flag.
- Fix some typos.

## Requirements
The required versions for `tqdm` and `typing-extensions` were not compatible with other modules. I've set them to be "equal or greater" (`>=`) rather than "exactly equal" (`==`).
Moreover, I've added the missing dependencies: `datasets` and `scikit-learn`.